### PR TITLE
feat(MR): Add number of unresolved threads on MR list page

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - `displayRecordBundleSize` - In our CI, we are getting the bundlesize of the our current build, this feature is here to display the size of the build.
 - `changeCountLabel` - Display the change count as label on the MR page.
 - `applyPrettier` - You can use Prettier formatter inside GitLab for the Issue and Merge request creation.
+- `displayUnresolvedThreads` - Display the count of unresolved threads of a MR on the MR list page
 
 # Disable features
 
@@ -39,6 +40,7 @@ Feature name:
 - `displayRecordBundleSize`
 - `changeCountLabel`
 - `applyPrettier`
+- `displayUnresolvedThreads`
 
 # Contribute
 

--- a/src/content.js
+++ b/src/content.js
@@ -10,6 +10,7 @@ import copyMR from "./features/copyMR";
 import displayRecordBundleSize from "./features/bundlesizeRecord";
 import applyPrettier from "./features/applyPrettier";
 import displayMRNameOnChanges from "./features/displayMRName";
+import displayUnresolvedThreads from "./features/displayUnresolvedThreads";
 
 // Utils Libs
 import * as pageDetect from "./utils/page-detect";
@@ -34,6 +35,7 @@ async function main() {
       enableFeature(await displayUserWhoThumbMR, disableFeatureSplit)();
       enableFeature(changeCountLabel, disableFeatureSplit)();
       enableFeature(sortWipState, disableFeatureSplit)();
+      enableFeature(await displayUnresolvedThreads, disableFeatureSplit)();
     }
   }
 

--- a/src/features/displayUnresolvedThreads.js
+++ b/src/features/displayUnresolvedThreads.js
@@ -1,0 +1,72 @@
+import { h } from "dom-chef";
+import select from "select-dom";
+
+import fetch from "../utils/api";
+import { getRepoName } from "../utils/page-detect";
+import { get, set } from "../utils/cache";
+
+async function populateChild(repoName, displayUnresolvedThreadsStruct) {
+  for (const mR of displayUnresolvedThreadsStruct) {
+    const discussionsRes = await fetch(
+      "get",
+      `projects/${repoName}/merge_requests/${mR.mrNumber}/discussions`
+    );
+
+    const numOfOpenedThreads = discussionsRes.data.reduce(
+      (total, discussion) => {
+        if (discussion.notes[0].resolvable && !discussion.notes[0].resolved) {
+          total++;
+        }
+        return total;
+      },
+      0
+    );
+    if (numOfOpenedThreads === 0) {
+      return;
+    }
+    mR.commentDiv.appendChild(
+      <span
+        class="has-tooltip"
+        data-original-title={`${numOfOpenedThreads} unresolved threads`}
+        style={{ color: "red" }}
+      >
+        ({numOfOpenedThreads})
+      </span>
+    );
+  }
+}
+
+async function displayUnresolvedThreads() {
+  const displayUnresolvedThreadsStruct = select
+    .all(".mr-list .merge-request .controls .issuable-comments")
+    .map((elem) => ({
+      mrNumber: /([0-9]+)/.exec(
+        select(".issuable-comments .has-tooltip", elem.parentNode).href
+      )[0],
+      commentDiv: elem,
+    }));
+
+  if (displayUnresolvedThreadsStruct.length === 0) {
+    return;
+  }
+
+  const repoName = getRepoName(
+    select("meta[property='og:title']").getAttribute("content")
+  );
+
+  const projectID = await get([repoName]);
+  if (projectID[repoName]) {
+    populateChild(projectID[repoName], displayUnresolvedThreadsStruct);
+  } else {
+    const projects = await fetch(
+      "get",
+      `projects?search=${repoName}&simple=true`
+    );
+    const projectIDStored = await set({
+      [repoName]: projects.data.filter((elem) => elem.name === repoName)[0].id,
+    });
+    populateChild(projectIDStored[repoName], displayUnresolvedThreadsStruct);
+  }
+}
+
+export default displayUnresolvedThreads;


### PR DESCRIPTION
New feature : `displayUnresolvedThreads `

This feature adds a counter showing the number of unresolved threads of a MR next to the total count of discussion of a MR, on the MR list page. 